### PR TITLE
#3 specify swift_version and update to new way of getting pngData() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.3.2
+* Added missing SWIFT_VERSION 4.2 to pod spec file for ios devices. (Thanks to [@qinwenshi](https://github.com/qinwenshi/flutter_pdf_renderer))
+
 ## 1.3.1
 * Added iOS support for rendering a pdf file from an absolute path.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -66,6 +66,7 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     target.build_configurations.each do |config|
       config.build_settings['ENABLE_BITCODE'] = 'NO'
+      config.build_settings['SWIFT_VERSION'] = '4.2'
     end
   end
 end

--- a/ios/Classes/SwiftFlutterPdfRendererPlugin.swift
+++ b/ios/Classes/SwiftFlutterPdfRendererPlugin.swift
@@ -66,7 +66,7 @@ public class SwiftFlutterPdfRendererPlugin: NSObject, FlutterPlugin {
     }
     
     private func storeImageToTemporaryDirectory(image: UIImage) -> URL? {
-        guard let data = image.pngData() else {
+        guard let data = UIImagePNGRepresentation(image) else {
             return nil
         }
         let fileURL = TemporaryFileURL(extension: "pdf")

--- a/ios/flutter_pdf_renderer.podspec
+++ b/ios/flutter_pdf_renderer.podspec
@@ -15,6 +15,7 @@ Flutter Plugin to render a PDF file.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
+  s.swift_version = '4.1'
 
   s.ios.deployment_target = '8.0'
 end

--- a/ios/flutter_pdf_renderer.podspec
+++ b/ios/flutter_pdf_renderer.podspec
@@ -15,7 +15,7 @@ Flutter Plugin to render a PDF file.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.swift_version = '4.1'
+  s.swift_version = '4.2'
 
   s.ios.deployment_target = '8.0'
 end

--- a/lib/flutter_pdf_renderer.dart
+++ b/lib/flutter_pdf_renderer.dart
@@ -6,12 +6,11 @@ import 'package:flutter/services.dart';
 
 class FlutterPdfRenderer {
   static const MethodChannel _channel =
-  MethodChannel('rackberg.flutter_pdf_renderer');
+      MethodChannel('rackberg.flutter_pdf_renderer');
 
   /// Sends the [pdfFile] to the platform which then renders it.
   static Future<List<File>> renderPdf({String pdfFile}) async {
-    final result =
-    await _channel.invokeMethod('renderPdf', <String, dynamic>{
+    final result = await _channel.invokeMethod('renderPdf', <String, dynamic>{
       'path': pdfFile,
     });
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_pdf_renderer
 description: Flutter Plugin to render PDF files on both Android and iOS devices. Provides a Widget to render the pages using a PageView.
-version: 1.3.1
+version: 1.3.2
 author: Lars Rosenberg <larsrosenberg88@gmail.com>
 homepage: https://github.com/rackberg/flutter_pdf_renderer
 


### PR DESCRIPTION
Specify swift_version in the pod spec file, and anyone who depends on the plugin can follow this. 
https://github.com/BaseflowIT/flutter-google-api-availability/issues/4#issuecomment-425134594

in my case, the Pod file looks like this
```ruby
target 'Runner' do
  use_frameworks!
  ......
  .....
end

post_install do |installer|
  installer.pods_project.targets.each do |target|
    target.build_configurations.each do |config|
      config.build_settings['SWIFT_VERSION'] = '4.1'
      config.build_settings['ENABLE_BITCODE'] = 'NO'
    end
  end
end
```